### PR TITLE
allow for multiple stores on the same redis database

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ redis-cookie-store is a Redis store for tough-cookie module. See
 ## Options
 
   `client` An existing redis client object you normally get from `redis.createClient()`
+  `id` defining an ID for each redis store so that we can use multiple stores with the same redis database
 
 ## Usage
 
@@ -18,7 +19,7 @@ redis-cookie-store is a Redis store for tough-cookie module. See
       var CookieJar = require("tough-cookie").CookieJar;
       var RedisCookieStore = require("redis-cookie-store");
 
-      var jar = new CookieJar(new RedisCookieStore(client));
+      var jar = new CookieJar(new RedisCookieStore(client), 'my-cookie-store');
 
 # License 
   

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ redis-cookie-store is a Redis store for tough-cookie module. See
 
 ## Options
 
-  `client` An existing redis client object you normally get from `redis.createClient()`
-  `id` defining an ID for each redis store so that we can use multiple stores with the same redis database
+  * `client` An existing redis client object you normally get from `redis.createClient()`
+  * `id` **optional** ID for each redis store so that we can use multiple stores with the same redis database [*default:* "default"]
 
 ## Usage
 
@@ -19,7 +19,9 @@ redis-cookie-store is a Redis store for tough-cookie module. See
       var CookieJar = require("tough-cookie").CookieJar;
       var RedisCookieStore = require("redis-cookie-store");
 
-      var jar = new CookieJar(new RedisCookieStore(client), 'my-cookie-store');
+      var defaultJar = new CookieJar(new RedisCookieStore(client));
+      
+      var myJar = new CookieJar(new RedisCookieStore(client, 'my-cookie-store'));
 
 # License 
   

--- a/lib/redis-cookie-store.js
+++ b/lib/redis-cookie-store.js
@@ -8,27 +8,29 @@ var async = require('async');
 var _ = require('lodash');
 var Cookie = tough.Cookie;
 
-function getKeyName(domain, path) {
-  if (path) {
-    return "cookie:" + domain + ":" + path;
-  } else {
-    return "cookie:" + domain;
-  }
-}
-
-function RedisCookieStore(redisClient) {
+// putting id last to not break existing interface
+function RedisCookieStore(redisClient, id) {
   Store.call(this);
   this.idx = {};
+  this.id = id || 'default';
   this.client = redisClient;
+  this.synchronous = false;
 }
 util.inherits(RedisCookieStore, Store);
-RedisCookieStore.prototype.synchronous = true;
 
-RedisCookieStore.prototype.findCookie = function (domain, path, key, cb) {
-  return this.client.hget(getKeyName(domain, path), key, cb);
+RedisCookieStore.prototype.getKeyName = function getKeyName(domain, path) {
+  if (path) {
+    return "cookie-store:" + this.id + ":cookie:" + domain + ":" + path;
+  } else {
+    return "cookie-store:" + this.id + ":cookie:" + domain;
+  }
 };
 
-RedisCookieStore.prototype.findCookies = function (domain, path, cb) {
+RedisCookieStore.prototype.findCookie = function(domain, path, key, cb) {
+  return this.client.hget(this.getKeyName(domain, path), key, cb);
+};
+
+RedisCookieStore.prototype.findCookies = function(domain, path, cb) {
   if (!domain) {
     return cb(null, []);
   }
@@ -36,109 +38,63 @@ RedisCookieStore.prototype.findCookies = function (domain, path, cb) {
   var domains = permuteDomain(domain) || [domain];
   var self = this;
 
-  var pathMatcher;
-  if (!path) {
-    // null or '/' means "all paths"
-    pathMatcher = function matchAll(domainKeys, cb) {
-      async.map(
-        domainKeys,
-        self.client.hgetall,
-        function (err, pathIndex) {
-          if (err) {
-            return cb(err);
-          }
-          var results = [];
-          for (var key in pathIndex) {
-            results.push(pathIndex[key]);
-          }
-          cb(null, results);
-        }
-      );
-    };
+  var paths = permutePath(path) || [path];
+  var pathMatcher = function matchRFC(domainKeys, cb) {
 
-  } else if (path === '/') {
-    pathMatcher = function matchSlash(domainKeys, cb) {
-      domainKeys.every(function (domainKey) {
-        if (domainKey.match(/cookie:.*:\/$/gi)) {
-          self.client.hgetall(
-            domainKey,
-            function (err, pathIndex) {
-              if (err) {
-                return cb(err);
-              }
-              var results = [];
-              for (var key in pathIndex) {
-                results.push(pathIndex[key]);
-              }
-              return cb(null, results);
-            }
-          );
-          return false;
-        }
-        return true;
-      });
-    };
+    var domainPrefix = domainKeys[0].match(/(.*cookie:[^:]*:)/i)[1]; //get domain key prefix e.g. "cookie:www.example.com"
+    var prefixedPaths = paths.map(function(path) {
+      return domainPrefix + path;
+    });
+    // console.log(prefixedPaths);
+    var keys = _.intersection(domainKeys, prefixedPaths).sort(function(a, b) {
+      return a.length - b.length;
+    });
 
-  } else {
-    var paths = permutePath(path) || [path];
-    pathMatcher = function matchRFC(domainKeys, cb) {
-      var domainPrefix = domainKeys[0].match(/(cookie:.*:)/i)[1]; //get domain key prefix e.g. "cookie:www.example.com"
-      paths = _.map(function (path) {
-        return domainPrefix + path;
-      });
-      var keys = _.intersection(domainKeys, paths);
-
-      async.map(
-        keys,
-        self.client.hgetall,
-        function (err, pathIndex) {
-          if (err) {
-            return cb(err);
-          }
-          var results = [];
-          for (var key in pathIndex) {
-            results.push(pathIndex[key]);
-          }
-          return cb(null, results);
-        }
-      );
-    };
-  }
-
-  async.map(
-    domains,
-    function (curDomain, mapCallback) {
-      self.client.keys(getKeyName(domain) + ":*", function (err, domainKeys) {
-        if (err) {
-          return mapCallback(err);
-        }
-        if (!domainKeys || !domainKeys.length) {
-          return mapCallback(null, null);
-        }
-        pathMatcher(domainKeys, mapCallback);
-      });
-    },
-    function (err, results) {
+    async.parallel(keys.map(function(key) {
+      return function(callback) {
+        self.client.hgetall(key, function(err, hash) {
+          callback(err, hash);
+        });
+      };
+    }), function(err, results) {
       if (err) {
         return cb(err);
       }
-      results = _.chain(results)
-        .flatten()
-        .compact()
-        .map(function (c) {
-          var cookie = Cookie.parse(c);
-          cookie.domain = domain;
-          return cookie;
-        })
-        .value();
+      cb(null, _.merge.apply(_, results));
+    });
+  };
 
-      return cb(null, results);
+
+  async.parallel(domains.sort(function(a, b) {
+    return a.length - b.length;
+  }).map(function(domain) {
+    return function(callback) {
+      self.client.keys(self.getKeyName(domain) + ":*", function(err, domainKeys) {
+        if (err) {
+          return callback(err, null);
+        }
+        if (!domainKeys || !domainKeys.length) {
+          return callback(null, {});
+        }
+        pathMatcher(domainKeys, callback);
+      });
+    };
+  }), function(err, results) {
+    if (err) {
+      return cb(err);
     }
-  );
+    cb(err, _.values(_.merge.apply(_, results)).map(function(cookieString) {
+      var cookie = Cookie.parse(cookieString);
+      if (!cookie.domain) {
+        cookie.domain = domain;
+      }
+      return cookie;
+    }));
+  });
 };
 
-RedisCookieStore.prototype.putCookie = function (cookie, cb) {
-  this.client.hset(getKeyName(cookie.domain, cookie.path), cookie.key, cookie, cb);
+RedisCookieStore.prototype.putCookie = function(cookie, cb) {
+  this.client.hset(this.getKeyName(cookie.domain, cookie.path), cookie.key, cookie, cb);
 };
 
 RedisCookieStore.prototype.updateCookie = function updateCookie(oldCookie, newCookie, cb) {
@@ -149,14 +105,14 @@ RedisCookieStore.prototype.updateCookie = function updateCookie(oldCookie, newCo
 };
 
 RedisCookieStore.prototype.removeCookie = function removeCookie(domain, path, key, cb) {
-  this.client.hdel(getKeyName(domain, path), key, cb);
+  this.client.hdel(this.getKeyName(domain, path), key, cb);
 };
 
 RedisCookieStore.prototype.removeCookies = function removeCookies(domain, path, cb) {
   if (path) {
-    return this.client.del(getKeyName(domain, path), cb);
+    return this.client.del(this.getKeyName(domain, path), cb);
   } else {
-    this.client.keys(getKeyName(domain) + ":*", function (err, keys) {
+    this.client.keys(this.getKeyName(domain) + ":*", function(err, keys) {
       if (err) {
         return cb(err);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-cookie-store",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Redis cookie store for tough-cookie module",
   "main": "index.js",
   "scripts": {
@@ -24,9 +24,8 @@
   },
   "homepage": "https://github.com/avovsya/redis-cookie-store",
   "dependencies": {
-    "async": "^0.9.0",
-    "lodash": "^2.4.1",
-    "redis": "^0.10.3",
-    "tough-cookie": "^0.12.1"
+    "async": "~0.9.0",
+    "lodash": "~3.7.0",
+    "tough-cookie": "~1.1.0"
   }
 }


### PR DESCRIPTION
* updated dependency modules
* the original stores all cookies in the same top-level redis key path structure, which makes it impossible to use the same redis database for multiple cookieJarStores.
* the store was flagged as synchronous, which it isn't. It uses an async database to store data.
* some modifications for cookie selection and aggregation of results

I'm using this version for over 1 year now in a production environment with > 90k concurrently managed cookie jars. No issues so far.
